### PR TITLE
Improve Docker build and install scripts

### DIFF
--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -1,19 +1,22 @@
-# Use the latest slim version of Debian
-FROM debian:bookworm-slim
+# Use the official Python image with a slim Debian base
+FROM python:3.11-slim
 
 # Check if the argument is provided, else throw an error
 ARG BRANCH
 RUN if [ -z "$BRANCH" ]; then echo "ERROR: BRANCH is not set!" >&2; exit 1; fi
 ENV BRANCH=$BRANCH
 
-# Set locale to en_US.UTF-8 and timezone to UTC
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales tzdata
-RUN sed -i -e 's/# \(en_US\.UTF-8 .*\)/\1/' /etc/locale.gen && \
+# Set locale to en_US.UTF-8 and timezone to UTC in a single layer
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        locales tzdata && \
+    sed -i -e 's/# \(en_US\.UTF-8 .*\)/\1/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-RUN echo "UTC" > /etc/timezone
-RUN dpkg-reconfigure -f noninteractive tzdata
+    update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8 && \
+    ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "UTC" > /etc/timezone && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    rm -rf /var/lib/apt/lists/*
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8

--- a/docker/run/fs/ins/install_playwright.sh
+++ b/docker/run/fs/ins/install_playwright.sh
@@ -9,7 +9,7 @@ pip install playwright
 # install chromium with dependencies
 # for kali-based
 if [ "$@" = "hacking" ]; then
-    apt-get install -y fonts-unifont libnss3 libnspr4
+    apt-get install -y --no-install-recommends fonts-unifont libnss3 libnspr4
     playwright install chromium-headless-shell
 else
     # for debian based

--- a/docker/run/fs/ins/install_searxng.sh
+++ b/docker/run/fs/ins/install_searxng.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install necessary packages
-apt-get install -y \
+apt-get install -y --no-install-recommends \
     python3-dev python3-babel python3-venv \
     uwsgi uwsgi-plugin-python3 \
     git build-essential libxslt-dev zlib1g-dev libffi-dev libssl-dev

--- a/docker/run/fs/ins/pre_install.sh
+++ b/docker/run/fs/ins/pre_install.sh
@@ -5,21 +5,21 @@ chmod 0644 /etc/cron.d/*
 
 echo "=====BEFORE UPDATE====="
 
-# Update and install necessary packages
-apt clean
-apt-get update && apt-get upgrade -y && apt-get install -y \
-    python3 \
-    python3-venv \
-    python3-pip \
-    nodejs \
-    openssh-server \
-    sudo \
-    curl \
-    wget \
-    git \
-    ffmpeg \
-    supervisor \
-    cron
+# Update and install necessary packages in one go
+apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        python3-venv \
+        python3-pip \
+        nodejs \
+        openssh-server \
+        sudo \
+        curl \
+        wget \
+        git \
+        ffmpeg \
+        supervisor \
+        cron
 
 echo "=====MID UPDATE====="
 


### PR DESCRIPTION
## Summary
- use official Python slim base image
- install locale/timezone packages in one layer with cleanup
- install base packages with `--no-install-recommends`
- make Playwright and SearXNG installs more minimal

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n docker/run/fs/ins/pre_install.sh`
- `bash -n docker/run/fs/ins/install_searxng.sh`
- `bash -n docker/run/fs/ins/install_playwright.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f742d56048323a5e3bea8c513f092